### PR TITLE
Don't lose Rococo and default to Frequency

### DIFF
--- a/client/src/lib/components/NetworkInput.svelte
+++ b/client/src/lib/components/NetworkInput.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { testnet } from "$lib/utils/stores";
-  import { Rococo, getChainName } from "../utils/networkData";
+  import { Frequency, getChainName } from "../utils/networkData";
   import Chevron from "./icons/Chevron.svelte";
 
   export let network: number = -1;
@@ -10,7 +10,7 @@
   let customValue: boolean = false;
   let customBtnMessage = "Use preselected chains";
   $: customBtnMessage = !customValue ? "Use custom chain id" : "Use preselected chains";
-  $: customValue = !getChainName(Rococo, network);
+  $: customValue = !getChainName(Frequency, network);
 
   function switchCustomValue() {
     if (!customValue) {

--- a/client/src/lib/utils/networkData.ts
+++ b/client/src/lib/utils/networkData.ts
@@ -21,12 +21,27 @@ export interface NetworkData {
 	explorer: string | null;
 }
 
-export const Rococo: NetworkData = {
+export const Frequency: NetworkData = {
 	networkName: "Frequency",
 	currency: "XRQCY",
 	chains: [{ name: "Frequency Rococo Testnet", id: -1 }],
 	endpoint: faucetUrl(PUBLIC_FAUCET_URL),
 	explorer: null
+};
+
+export const Rococo: NetworkData = {
+	networkName: "Rococo",
+	currency: "ROC",
+	chains: [
+		{ name: "Rococo Relay", id: -1 },
+		{ name: "AssetHub", id: 1000 },
+		{ name: "Contracts", id: 1002 },
+		{ name: "Encointer Lietaer", id: 1003 },
+		{ name: "Coretime", id: 1005 },
+		{ name: "Bridgehub", id: 1013 }
+	],
+	endpoint: faucetUrl("https://rococo-faucet.parity-testnet.parity.io/drip/web"),
+	explorer: "https://rococo.subscan.io"
 };
 
 export const Westend: NetworkData = {
@@ -60,6 +75,7 @@ export const Trappist: NetworkData = {
 };
 
 export const Networks: { network: NetworkData; url: string }[] = [
+	{ network: Frequency, url: "/" },
 	{ network: Rococo, url: "https://faucet.polkadot.io" },
 	{ network: Paseo, url: "https://faucet.polkadot.io/paseo" },
 	{ network: Westend, url: "https://faucet.polkadot.io/westend" },

--- a/client/src/routes/+page.svelte
+++ b/client/src/routes/+page.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import Faucet from "$lib/components/Faucet.svelte";
-  import { Rococo, type NetworkData } from "$lib/utils/networkData";
+  import { type NetworkData, Frequency } from "$lib/utils/networkData";
   import faqMd from "$lib/assets/FAQ.md?raw";
 
-  let network: NetworkData = Rococo;
+  let network: NetworkData = Frequency;
   let faq: string = faqMd
     .replaceAll("<NETWORK-TOKEN>", network.currency)
     .replaceAll("<NETWORK-NAME>", network.networkName);


### PR DESCRIPTION
## Goal

The goal of this PR is to fix the missing Rococo from the dropdown and correctly default to Frequency in the UI

## Checklist

- [x] PR Self-Review and Commenting

## How To Test the Changes

1. Clone the pr branch
2. `cd client`
3. `yarn dev`
4. See the dropdowns correctly

<img width="570" alt="image" src="https://github.com/frequency-chain/testnet-faucet/assets/1252199/4948a657-c60f-4627-af42-9584486459a8">

