### PR TITLE
fix yarn run build,  Docker build

### DIFF
--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -16,6 +16,17 @@ permissions:
 jobs:
   build-faucet:
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: yarn install --frozen-lockfile
+      - run: yarn run build
+  build-faucet-client:
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: client

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.2",
     "ts-patch": "^3.2.1",
-    "typescript": "^5.1.3",
-    "typescript-transform-paths": "^3.5.1"
+    "typescript": "^4.9.3",
+    "typescript-transform-paths": "^3.4.6"
   }
 }

--- a/src/faucet.e2e.ts
+++ b/src/faucet.e2e.ts
@@ -214,7 +214,7 @@ describe("Faucet E2E", () => {
 
     const oldDrip = new Drip();
     oldDrip.addressSha256 = sha256(userAddress);
-    oldDrip.timestamp = BigInt(Date.now() - 30 * 60 * 60 * 1000);
+    oldDrip.timestamp = Date.now() - 30 * 60 * 60 * 1000;
     dripRepository.insert(oldDrip);
 
     const result = await drip(webEndpoint, userAddress);
@@ -227,7 +227,7 @@ describe("Faucet E2E", () => {
 
     const oldDrip = new Drip();
     oldDrip.addressSha256 = sha256(userAddress);
-    oldDrip.timestamp = BigInt(Date.now() - 5 * 60 * 60 * 1000);
+    oldDrip.timestamp = Date.now() - 5 * 60 * 60 * 1000;
     await dripRepository.insert(oldDrip);
 
     await expect(drip(webEndpoint, userAddress)).rejects.toThrow(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
+    "baseUrl": "./",
     "declaration": true,
     "emitDecoratorMetadata": true,
     "esModuleInterop": true,
@@ -11,7 +11,7 @@
     "moduleResolution": "node",
     "outDir": "./build",
     "paths": {
-      "src/*": ["/src/*"]
+      "src/*": ["./src/*"]
     },
     "plugins": [
       // Transform paths in output .js files
@@ -27,5 +27,6 @@
     "typeRoots": ["./node_modules/@types", "./src/types"]
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules/**/*"]
+  // e2e tests don't compile and aren't run by us
+  "exclude": ["node_modules/**/*", "src/faucet.e2e.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8641,7 +8641,7 @@ typeorm@0.3.21-dev.e7649d2:
     uuid "^9.0.0"
     yargs "^17.6.2"
 
-typescript-transform-paths@^3.5.1:
+typescript-transform-paths@^3.4.6:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/typescript-transform-paths/-/typescript-transform-paths-3.5.1.tgz#472a4223ad9463b88fd9ef3dc1ec0616018c4294"
   integrity sha512-nq+exuF+38rAby9zrP+S6t0HWuwv69jeFu0I5UwjdoCIDPmnKIAr6a7JfYkbft7h5OzYKEDRhT/jLvvtTvWF4Q==
@@ -8653,7 +8653,12 @@ typescript@4.6.3:
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz"
   integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
 
-typescript@^5.1.3, typescript@^5.3.2, typescript@^5.5.4:
+typescript@^4.9.3:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+
+typescript@^5.3.2, typescript@^5.5.4:
   version "5.6.2"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz"
   integrity sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==


### PR DESCRIPTION
Docker build was broken because the top level `yarn run build` was broken.  It looks like it was because of this problem which keeps coming up: https://github.com/LeDDGroup/typescript-transform-paths/issues/266

1. Fix the build by backing down a version of tsc and friends until other tools catch up
2. Add a `yarn run build` step to verify-pr workflow.  I'm keeping these as separate checkout and run steps because they are also built separately on a merge and deployed in different places.